### PR TITLE
Translate reflection notebooks to Korean

### DIFF
--- a/docs/docs/tutorials/reflection/reflection.ipynb
+++ b/docs/docs/tutorials/reflection/reflection.ipynb
@@ -10,15 +10,14 @@
    "id": "492f050f-3dc3-44fa-8fdc-03362afd5488",
    "metadata": {},
    "source": [
-    "# Reflection\n",
+    "# 반성\n",
     "\n",
-    "\n",
-    "In the context of LLM agent building, reflection refers to the process of prompting an LLM to observe its past steps (along with potential observations from tools/the environment) to assess the quality of the chosen actions.\n",
-    "This is then used downstream for things like re-planning, search, or evaluation.\n",
+    "LLM 에이전트를 구축할 때 '반성(reflection)'은 LLM에게 과거 단계(도구나 환경에서 얻은 관찰을 포함)를 살펴보고 선택한 행동의 품질을 평가하도록 프롬프트하는 과정을 의미합니다.\n",
+    "이 결과는 재계획, 탐색, 평가 등의 후속 단계에서 사용됩니다.\n",
     "\n",
     "![Reflection](attachment:fc393f72-3401-4b86-b0d3-e4789b640a27.png)\n",
     "\n",
-    "This notebook demonstrates a very simple form of reflection in LangGraph."
+    "이 노트북은 LangGraph에서 매우 단순한 형태의 반성 기법을 보여줍니다."
    ]
   },
   {
@@ -26,9 +25,9 @@
    "id": "3ef94e7e-c9a5-4eee-a865-acf411b5c235",
    "metadata": {},
    "source": [
-    "## Setup\n",
+    "## 설정\n",
     "\n",
-    "First, let's install our required packages and set our API keys"
+    "먼저 필요한 패키지를 설치하고 API 키를 설정해 봅시다."
    ]
   },
   {
@@ -69,9 +68,9 @@
    "metadata": {},
    "source": [
     "<div class=\"admonition tip\">\n",
-    "    <p class=\"admonition-title\">Set up <a href=\"https://smith.langchain.com\">LangSmith</a> for LangGraph development</p>\n",
+    "    <p class=\"admonition-title\"><a href=\"https://smith.langchain.com\">LangSmith</a>를 설정하여 LangGraph 개발을 시작하세요</p>\n",
     "    <p style=\"padding-top: 5px;\">\n",
-    "        Sign up for LangSmith to quickly spot issues and improve the performance of your LangGraph projects. LangSmith lets you use trace data to debug, test, and monitor your LLM apps built with LangGraph — read more about how to get started <a href=\"https://docs.smith.langchain.com\">here</a>. \n",
+    "        LangSmith에 가입하면 LangGraph 프로젝트의 문제를 빠르게 파악하고 성능을 향상시킬 수 있습니다. LangSmith는 LangGraph로 구축한 LLM 앱을 디버깅하고 테스트하며 모니터링할 수 있도록 추적 데이터를 제공합니다. 시작하는 방법은 <a href=\"https://docs.smith.langchain.com\">여기</a>에서 자세히 알아보세요. \n",
     "    </p>\n",
     "</div>"
    ]
@@ -81,9 +80,9 @@
    "id": "f27bcc4a-aaa5-46bd-8163-3e0e90cb66e6",
    "metadata": {},
    "source": [
-    "## Generate\n",
+    "## 생성\n",
     "\n",
-    "For our example, we will create a \"5 paragraph essay\" generator. First, create the generator:\n"
+    "예제로 \"5단락 에세이\" 생성기를 만들어 보겠습니다. 먼저 생성기를 만듭니다:\n"
    ]
   },
   {
@@ -101,9 +100,9 @@
     "    [\n",
     "        (\n",
     "            \"system\",\n",
-    "            \"You are an essay assistant tasked with writing excellent 5-paragraph essays.\"\n",
-    "            \" Generate the best essay possible for the user's request.\"\n",
-    "            \" If the user provides critique, respond with a revised version of your previous attempts.\",\n",
+    "            \"당신은 훌륭한 5단락 에세이를 작성하는 에세이 도우미입니다.\"\n",
+    "            \" 사용자 요청에 대해 가능한 최고의 에세이를 생성하세요.\"\n",
+    "            \" 사용자가 비평을 제공하면 이전 시도를 수정한 버전으로 응답하세요.\",\n",
     "        ),\n",
     "        MessagesPlaceholder(variable_name=\"messages\"),\n",
     "    ]\n",
@@ -149,7 +148,7 @@
    "source": [
     "essay = \"\"\n",
     "request = HumanMessage(\n",
-    "    content=\"Write an essay on why the little prince is relevant in modern childhood\"\n",
+    "    content=\"현대 어린 시절에 \"어린 왕자\"가 왜 관련성이 있는지에 대한 에세이를 작성하세요\"\n",
     ")\n",
     "for chunk in generate.stream({\"messages\": [request]}):\n",
     "    print(chunk.content, end=\"\")\n",
@@ -161,7 +160,7 @@
    "id": "b0b276e7-c392-4eec-be75-c77bd130379d",
    "metadata": {},
    "source": [
-    "### Reflect"
+    "### 반성"
    ]
   },
   {
@@ -175,8 +174,8 @@
     "    [\n",
     "        (\n",
     "            \"system\",\n",
-    "            \"You are a teacher grading an essay submission. Generate critique and recommendations for the user's submission.\"\n",
-    "            \" Provide detailed recommendations, including requests for length, depth, style, etc.\",\n",
+    "            \"당신은 에세이 제출물을 채점하는 교사입니다. 사용자의 제출물에 대한 비평과 추천을 생성하세요.\"\n",
+    "            \" 길이, 깊이, 스타일 등과 관련된 구체적인 권장 사항을 제공하세요.\",\n",
     "        ),\n",
     "        MessagesPlaceholder(variable_name=\"messages\"),\n",
     "    ]\n",
@@ -238,9 +237,9 @@
    "id": "6daf926c-1174-4e96-91b9-57c57cfce40d",
    "metadata": {},
    "source": [
-    "### Repeat\n",
+    "### 반복\n",
     "\n",
-    "And... that's all there is too it! You can repeat in a loop for a fixed number of steps, or use an LLM (or other check) to decide when the finished product is good enough."
+    "이게 전부입니다! 정해진 횟수만큼 반복문을 돌리거나, LLM(또는 다른 검사)을 사용하여 결과물이 충분히 만족스러울 때를 결정할 수 있습니다."
    ]
   },
   {
@@ -307,9 +306,9 @@
    "id": "b63a9d93-a14d-4e41-a4bb-a4cd31713f44",
    "metadata": {},
    "source": [
-    "## Define graph\n",
+    "## 그래프 정의\n",
     "\n",
-    "Now that we've shown each step in isolation, we can wire it up in a graph."
+    "이제 각 단계를 개별적으로 살펴보았으니, 그래프에 연결해 보겠습니다."
    ]
   },
   {
@@ -335,14 +334,14 @@
     "\n",
     "\n",
     "async def reflection_node(state: State) -> State:\n",
-    "    # Other messages we need to adjust\n",
+    "    # 다른 메시지를 조정해야 합니다\n",
     "    cls_map = {\"ai\": HumanMessage, \"human\": AIMessage}\n",
-    "    # First message is the original user request. We hold it the same for all nodes\n",
+    "    # 첫 번째 메시지는 원래의 사용자 요청입니다. 모든 노드에서 동일하게 유지합니다\n",
     "    translated = [state[\"messages\"][0]] + [\n",
     "        cls_map[msg.type](content=msg.content) for msg in state[\"messages\"][1:]\n",
     "    ]\n",
     "    res = await reflect.ainvoke(translated)\n",
-    "    # We treat the output of this as human feedback for the generator\n",
+    "    # 이 출력은 생성기에 대한 인간의 피드백으로 간주합니다\n",
     "    return {\"messages\": [HumanMessage(content=res.content)]}\n",
     "\n",
     "\n",
@@ -354,7 +353,7 @@
     "\n",
     "def should_continue(state: State):\n",
     "    if len(state[\"messages\"]) > 6:\n",
-    "        # End after 3 iterations\n",
+    "        # 3번 반복 후 종료\n",
     "        return END\n",
     "    return \"reflect\"\n",
     "\n",
@@ -409,7 +408,7 @@
     "    {\n",
     "        \"messages\": [\n",
     "            HumanMessage(\n",
-    "                content=\"Generate an essay on the topicality of The Little Prince and its message in modern life\"\n",
+    "                content=\"현대 사회에서 \"어린 왕자\"의 시의성과 그 메시지에 대한 에세이를 작성하세요\"\n",
     "            )\n",
     "        ],\n",
     "    },\n",
@@ -605,9 +604,9 @@
     "jp-MarkdownHeadingCollapsed": true
    },
    "source": [
-    "## Conclusion\n",
+    "## 마무리\n",
     "\n",
-    "Now that you've applied reflection to an LLM agent, I'll note one thing: self-reflection is inherently cyclic: it is much more effective if the reflection step has additional context or feedback (from tool observations, checks, etc.). If, like in the scenario above, the reflection step simply prompts the LLM to reflect on its output, it can still benefit the output quality (since the LLM then has multiple \"shots\" at getting a good output), but it's less guaranteed.\n"
+    "이제 LLM 에이전트에 반성을 적용해 보았으니 한 가지를 짚고 넘어가겠습니다. 자기 반성은 본질적으로 순환적이며, 반성 단계가 도구 관찰, 검사 등 추가적인 맥락이나 피드백을 포함할 때 훨씬 더 효과적입니다. 위의 예시처럼 반성 단계가 단순히 LLM에게 자신의 출력에 대해 반성하도록 요청하는 것이라면, LLM이 좋은 출력을 얻을 기회를 여러 번 갖게 되어 품질이 향상될 수 있지만, 그 효과는 보장되지 않습니다.\n"
    ]
   }
  ],

--- a/examples/reflection/reflection.ipynb
+++ b/examples/reflection/reflection.ipynb
@@ -5,7 +5,7 @@
    "id": "658773a2",
    "metadata": {},
    "source": [
-    "This file has been moved to https://github.com/langchain-ai/langgraph/blob/main/docs/docs/tutorials/reflection/reflection.ipynb"
+    "이 파일은 https://github.com/langchain-ai/langgraph/blob/main/docs/docs/tutorials/reflection/reflection.ipynb 로 이동했습니다"
    ]
   }
  ],


### PR DESCRIPTION
## Summary
- localize reflection tutorial notebook text to Korean
- translate example reflection stub to Korean

## Testing
- `make format` *(fails: Failed to download `charset-normalizer`)*
- `make lint` *(fails: Failed to download `pydantic-core`)*
- `make test` *(fails: Failed to download `langchain-core`)*

------
https://chatgpt.com/codex/tasks/task_e_6891c95a340483228d3d1c2f496f45ef